### PR TITLE
docs: add tsdoc comments

### DIFF
--- a/src/hooks/usePokemon.ts
+++ b/src/hooks/usePokemon.ts
@@ -1,14 +1,29 @@
 import { useState, useEffect } from 'react';
-import { fallbackPokemon, fallbackGeneration } from '@/data/fallback-pokemon';
+import { fallbackPokemon } from '@/data/fallback-pokemon';
 
+/**
+ * @fileoverview React hook and helpers for loading and caching Pokemon data
+ * from the PokeAPI with graceful fallbacks for offline or error scenarios.
+ *
+ * @author ejparnell
+ * @since 1.0.0
+ */
+
+/**
+ * Minimal representation of a Pokemon as returned by the PokeAPI.
+ */
 interface Pokemon {
+  /** Pokedex ID of the Pokemon. */
   id: number;
+  /** Pokemon species name. */
   name: string;
+  /** Pokemon type information. */
   types: Array<{
     type: {
       name: string;
     };
   }>;
+  /** Sprite images for the Pokemon. */
   sprites: {
     front_default: string;
     other: {
@@ -17,19 +32,28 @@ interface Pokemon {
       };
     };
   };
+  /** Base stats for the Pokemon. */
   stats: Array<{
     base_stat: number;
     stat: {
       name: string;
     };
   }>;
+  /** Height in decimetres. */
   height: number;
+  /** Weight in hectograms. */
   weight: number;
 }
 
+/**
+ * Representation of a Pokemon generation including all Pokemon loaded for it.
+ */
 interface Generation {
+  /** Numeric generation identifier. */
   id: number;
+  /** Human readable name for the generation. */
   name: string;
+  /** Pokemon belonging to the generation. */
   pokemon: Pokemon[];
 }
 
@@ -45,14 +69,28 @@ const GENERATION_RANGES = {
   9: { start: 906, end: 1025, name: "Generation IX (Paldea)" }
 };
 
-// In-memory cache for Pokemon data
+/** In-memory cache for Pokemon data mapped by generation. */
 const pokemonCache = new Map<number, { data: Generation; timestamp: number }>();
 
+/**
+ * Hook that provides Pokemon generation data and utilities for retrieving
+ * random Pokemon encounters. Data is cached in-memory to reduce API calls.
+ *
+ * @returns Object containing generation data and helper methods.
+ */
 export function usePokemon() {
   const [generations, setGenerations] = useState<Generation[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  /**
+   * Fetches Pokemon information by ID from the PokeAPI with simple retry
+   * and HTTP fallback behaviour.
+   *
+   * @param id - Pokedex ID of the Pokemon to fetch.
+   * @param retries - Number of retry attempts on failure.
+   * @returns Resolved Pokemon object or `null` if unavailable.
+   */
   const fetchPokemonData = async (id: number, retries = 2): Promise<Pokemon | null> => {
     try {
       // Try HTTPS first, fallback to HTTP if SSL issues
@@ -83,6 +121,13 @@ export function usePokemon() {
     }
   };
 
+  /**
+   * Loads an entire generation of Pokemon, utilising an in-memory cache
+   * that expires after 24 hours.
+   *
+   * @param genId - Numeric generation identifier to load.
+   * @returns Generation data or `null` if retrieval fails.
+   */
   const fetchGeneration = async (genId: number): Promise<Generation | null> => {
     // Check in-memory cache first
     const cached = pokemonCache.get(genId);
@@ -181,6 +226,12 @@ export function usePokemon() {
     }
   };
 
+  /**
+   * Loads a generation and merges it into state, replacing existing data
+   * if the generation is already present.
+   *
+   * @param genId - Generation identifier to load.
+   */
   const loadGeneration = async (genId: number) => {
     const generation = await fetchGeneration(genId);
     if (generation) {
@@ -194,6 +245,10 @@ export function usePokemon() {
     }
   };
 
+  /**
+   * Loads all generations sequentially, updating loading state and error
+   * handling appropriately.
+   */
   const loadAllGenerations = async () => {
     setLoading(true);
     setError(null);
@@ -210,11 +265,21 @@ export function usePokemon() {
     }
   };
 
+  /**
+   * Clears the in-memory cache and resets loaded generations.
+   */
   const clearCache = () => {
     pokemonCache.clear();
     setGenerations([]);
   };
 
+  /**
+   * Retrieves a random Pokemon from the loaded cache, optionally targeting
+   * a specific Pokemon by ID.
+   *
+   * @param targetPokemonId - Specific Pokemon ID to attempt to retrieve.
+   * @returns A Pokemon object or `null` if none are available.
+   */
   const getRandomPokemonFromCache = (targetPokemonId?: number): Pokemon | null => {
     const allGenerations = Array.from(pokemonCache.values()).map(cached => cached.data);
     

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,6 +5,19 @@ import { dbConnect } from './database';
 import { User } from '@/models/user';
 import { loginSchema } from '@/utils/schemas/auth-schema';
 
+/**
+ * @fileoverview Configuration for NextAuth.js authentication using a
+ * custom credentials provider backed by MongoDB.
+ *
+ * @author ejparnell
+ * @since 1.0.0
+ */
+
+/**
+ * NextAuth configuration that sets up credential-based authentication
+ * with email and password. Users are validated against the MongoDB
+ * `User` model and authenticated via bcrypt password comparison.
+ */
 export const authOptions: NextAuthOptions = {
     session: { strategy: 'jwt' },
     providers: [

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,17 +1,37 @@
 import mongoose, { Connection } from 'mongoose';
 
+/**
+ * @fileoverview Database connection utilities for managing a singleton
+ * MongoDB connection throughout the application.
+ *
+ * @author ejparnell
+ * @since 1.0.0
+ */
+
 const MONGODB_URI = process.env.MONGODB_URI as string;
 
 if (!MONGODB_URI) throw new Error('MONGODB_URI missing in env');
 
 declare global {
-    // eslint-disable-next-line no-var
+    /**
+     * Cached Mongoose connection reference stored in the global scope to
+     * prevent creating multiple connections in a serverless environment.
+     */
     var mongooseConn: {
+        /** Active Mongoose connection instance. */
         conn: Connection | null;
+        /** Promise resolving to a connection, used while connecting. */
         promise: Promise<Connection> | null;
     };
 }
 
+/**
+ * Establishes a connection to MongoDB using Mongoose. The connection is
+ * cached on the `global` object to ensure a single instance is reused
+ * across hot reloads and serverless invocations.
+ *
+ * @returns A promise that resolves to an active {@link Connection}.
+ */
 export async function dbConnect(): Promise<Connection> {
     if (global.mongooseConn?.conn) return global.mongooseConn.conn;
 

--- a/src/lib/importer.ts
+++ b/src/lib/importer.ts
@@ -4,7 +4,22 @@ import { Application } from '@/models/application';
 import { ApplicationData, JobApplication } from '@/types/applications';
 import { dbConnect } from '@/lib/database';
 
+/**
+ * @fileoverview Utility class for importing and exporting job application
+ * data to and from the application's MongoDB store.
+ *
+ * @author ejparnell
+ * @since 1.0.0
+ */
+
 export class ApplicationImporter {
+  /**
+   * Imports job applications from a JSON file on disk.
+   *
+   * @param filePath - Path to the JSON file to import.
+   * @param userId - User ID to associate the imported applications with.
+   * @returns Summary of the import process including counts and errors.
+   */
   static async importFromJSON(filePath: string, userId: string): Promise<{
     success: boolean;
     imported: number;
@@ -68,6 +83,13 @@ export class ApplicationImporter {
     return result;
   }
   
+  /**
+   * Imports job applications from an in-memory array of job records.
+   *
+   * @param jobs - Array of job application objects to import.
+   * @param userId - User ID to associate the applications with.
+   * @returns Summary of the import process.
+   */
   static async importFromArray(jobs: JobApplication[], userId: string): Promise<{
     success: boolean;
     imported: number;
@@ -125,6 +147,12 @@ export class ApplicationImporter {
     return result;
   }
   
+  /**
+   * Cleans HTML-laden job descriptions into Markdown-like plain text.
+   *
+   * @param description - Raw HTML job description.
+   * @returns Sanitized description limited to 5000 characters.
+   */
   static cleanDescription(description: string): string {
     return description
       .replace(/<br\s*\/?>/gi, '\n')
@@ -137,6 +165,14 @@ export class ApplicationImporter {
       .substring(0, 5000);
   }
   
+  /**
+   * Exports a user's applications to a JSON object and optionally writes
+   * it to disk.
+   *
+   * @param userId - User whose applications are exported.
+   * @param filePath - Optional file system path to write the JSON data to.
+   * @returns Structured application data ready for export.
+   */
   static async exportToJSON(userId: string, filePath?: string): Promise<ApplicationData> {
     await dbConnect();
     
@@ -181,6 +217,13 @@ export class ApplicationImporter {
     return exportData;
   }
   
+  /**
+   * Convenience method that imports applications from the `data.json` file
+   * located at the project root.
+   *
+   * @param userId - User ID to associate imported applications with.
+   * @returns Summary of the import process.
+   */
   static async migrateDataFromRoot(userId: string): Promise<{
     success: boolean;
     imported: number;

--- a/src/lib/pokemon-gamification.ts
+++ b/src/lib/pokemon-gamification.ts
@@ -1,28 +1,61 @@
 import mongoose, { Schema, Document } from 'mongoose';
 
+/**
+ * @fileoverview Mongoose models and interfaces that power the Pokemon
+ * gamification features, including caught Pokemon records and user
+ * application statistics.
+ *
+ * @author ejparnell
+ * @since 1.0.0
+ */
+
+/**
+ * Document representing a Pokemon caught by a user.
+ */
 export interface ICaughtPokemon extends Document {
+  /** User identifier that caught the Pokemon. */
   userId: string;
+  /** Numeric ID of the Pokemon species. */
   pokemonId: number;
+  /** Pokemon name. */
   name: string;
+  /** URL to the Pokemon sprite. */
   sprite: string;
+  /** Type names associated with the Pokemon. */
   types: string[];
+  /** Pokemon height in decimetres. */
   height: number;
+  /** Pokemon weight in hectograms. */
   weight: number;
+  /** Timestamp when the Pokemon was caught. */
   caughtAt: Date;
+  /** Encounter chance percentage used when catching. */
   encounterChance: number;
+  /** Application streak value at the time of capture. */
   applicationStreak: number;
 }
 
+/**
+ * Document storing aggregate stats for a user's Pokemon encounters.
+ */
 export interface IUserPokemonStats extends Document {
+  /** Associated user identifier. */
   userId: string;
+  /** Total number of job applications submitted by the user. */
   totalApplications: number;
+  /** Current consecutive application streak. */
   currentStreak: number;
+  /** Date of the user's last recorded application. */
   lastApplicationDate: Date | null;
+  /** Total number of Pokemon caught by the user. */
   totalPokemonCaught: number;
+  /** Current encounter rate used for gamification. */
   currentEncounterRate: number;
+  /** Timestamp of the last stats update. */
   updatedAt: Date;
 }
 
+/** Schema for storing caught Pokemon information. */
 const CaughtPokemonSchema = new Schema<ICaughtPokemon>({
   userId: { type: String, required: true, index: true },
   pokemonId: { type: Number, required: true },
@@ -36,6 +69,7 @@ const CaughtPokemonSchema = new Schema<ICaughtPokemon>({
   applicationStreak: { type: Number, required: true }
 });
 
+/** Schema for storing cumulative user statistics. */
 const UserPokemonStatsSchema = new Schema<IUserPokemonStats>({
   userId: { type: String, required: true, unique: true, index: true },
   totalApplications: { type: Number, default: 0 },
@@ -50,5 +84,12 @@ const UserPokemonStatsSchema = new Schema<IUserPokemonStats>({
 CaughtPokemonSchema.index({ userId: 1, caughtAt: -1 });
 CaughtPokemonSchema.index({ userId: 1, pokemonId: 1 });
 
-export const CaughtPokemon = mongoose.models.CaughtPokemon || mongoose.model<ICaughtPokemon>('CaughtPokemon', CaughtPokemonSchema);
-export const UserPokemonStats = mongoose.models.UserPokemonStats || mongoose.model<IUserPokemonStats>('UserPokemonStats', UserPokemonStatsSchema);
+/** Mongoose model for caught Pokemon documents. */
+export const CaughtPokemon =
+  mongoose.models.CaughtPokemon ||
+  mongoose.model<ICaughtPokemon>('CaughtPokemon', CaughtPokemonSchema);
+
+/** Mongoose model for user Pokemon statistics documents. */
+export const UserPokemonStats =
+  mongoose.models.UserPokemonStats ||
+  mongoose.model<IUserPokemonStats>('UserPokemonStats', UserPokemonStatsSchema);

--- a/src/lib/pokemon-service.ts
+++ b/src/lib/pokemon-service.ts
@@ -1,7 +1,23 @@
 import { CaughtPokemon, UserPokemonStats } from './pokemon-gamification';
 import { dbConnect } from './database';
-import type { PokemonEncounter, CaughtPokemon as CaughtPokemonType, UserPokemonStats as UserPokemonStatsType } from '@/models/pokemon';
+import type {
+  PokemonEncounter,
+  CaughtPokemon as CaughtPokemonType,
+  UserPokemonStats as UserPokemonStatsType
+} from '@/models/pokemon';
 
+/**
+ * @fileoverview Service encapsulating Pokemon encounter logic and user
+ * gamification statistics for job applications.
+ *
+ * @author ejparnell
+ * @since 1.0.0
+ */
+
+/**
+ * Provides utilities to trigger encounters, store captured Pokemon and
+ * retrieve statistics related to the gamification system.
+ */
 export class PokemonGamificationService {
   private static readonly BASE_ENCOUNTER_RATE = 0.15; // 15%
   private static readonly STREAK_BONUS = 0.05; // 5% per day
@@ -10,9 +26,12 @@ export class PokemonGamificationService {
   private static readonly MAX_POKEMON_ID = 1010;
 
   /**
-   * Handles a job application and potential Pokemon encounter
-   * This method only calculates encounter rates and returns the encounter result
-   * Frontend will handle Pokemon selection from cached data
+   * Handles a job application and calculates whether a Pokemon encounter
+   * occurs. The actual Pokemon selection is performed client-side using
+   * cached data.
+   *
+   * @param userId - Identifier of the user applying for a job.
+   * @returns Encounter result including chance and potential Pokemon data.
    */
   static async triggerEncounter(userId: string): Promise<PokemonEncounter> {
     await dbConnect();
@@ -61,7 +80,10 @@ export class PokemonGamificationService {
   }
 
   /**
-   * Updates user application stats and streak
+   * Updates the user's application statistics and streak values.
+   *
+   * @param userId - User identifier whose stats are updated.
+   * @returns Updated user Pokemon statistics document.
    */
   private static async updateUserStats(userId: string): Promise<UserPokemonStatsType> {
     const now = new Date();
@@ -118,21 +140,29 @@ export class PokemonGamificationService {
   }
 
   /**
-   * Saves a caught Pokemon to the database (called after frontend selects Pokemon from cache)
+   * Persists a caught Pokemon to the database after an encounter is
+   * resolved on the client.
+   *
+   * @param userId - ID of the user who caught the Pokemon.
+   * @param pokemonId - Numeric ID of the captured Pokemon.
+   * @param pokemonData - Detailed Pokemon data from the PokeAPI cache.
+   * @param encounterChance - Encounter probability used when catching.
+   * @param streak - User's application streak at capture time.
+   * @returns The saved {@link CaughtPokemonType} document.
    */
   static async saveCaughtPokemon(
     userId: string,
     pokemonId: number,
-    pokemonData: { 
-      id: number; 
-      name: string; 
-      sprites: { 
-        other: { 'official-artwork': { front_default: string } }; 
-        front_default: string; 
-      }; 
-      types: { type: { name: string } }[]; 
-      height: number; 
-      weight: number; 
+    pokemonData: {
+      id: number;
+      name: string;
+      sprites: {
+        other: { 'official-artwork': { front_default: string } };
+        front_default: string;
+      };
+      types: { type: { name: string } }[];
+      height: number;
+      weight: number;
     },
     encounterChance: number,
     streak: number
@@ -158,7 +188,10 @@ export class PokemonGamificationService {
   }
 
   /**
-   * Gets user's Pokemon collection
+   * Retrieves a user's caught Pokemon collection sorted by capture date.
+   *
+   * @param userId - ID of the user whose collection is requested.
+   * @returns Array of caught Pokemon documents.
    */
   static async getUserCollection(userId: string): Promise<CaughtPokemonType[]> {
     await dbConnect();
@@ -184,7 +217,10 @@ export class PokemonGamificationService {
   }
 
   /**
-   * Gets user's Pokemon stats
+   * Fetches gamification statistics for a given user.
+   *
+   * @param userId - User identifier.
+   * @returns User stats or `null` if none exist.
    */
   static async getUserStats(userId: string): Promise<UserPokemonStatsType | null> {
     await dbConnect();
@@ -205,7 +241,10 @@ export class PokemonGamificationService {
   }
 
   /**
-   * Gets collection statistics
+   * Computes aggregate statistics about a user's Pokemon collection.
+   *
+   * @param userId - ID of the user for whom stats are calculated.
+   * @returns Summary of collection metrics including totals and streaks.
    */
   static async getCollectionStats(userId: string) {
     await dbConnect();


### PR DESCRIPTION
## Summary
- document database connection helper and gamification models
- annotate pokemon gamification service and application importer
- add TSDoc for auth configuration and pokemon hook

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Error: 'NextRequest' is defined but never used., Error: 'error' is defined but never used., Error: 'isUnprotectedRoute' is assigned a value but never used., Error: `"` can be escaped with `&quot;`, `&ldquo;`, `&#34;`, `&rdquo;`)

------
https://chatgpt.com/codex/tasks/task_e_689ca90711608326b9d07fc16e7c9a38